### PR TITLE
Tweaks for new autobrew, incl arm64 support

### DIFF
--- a/configure
+++ b/configure
@@ -32,20 +32,12 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [ "$(command -v brew)" ]; then
     BREWDIR=$(brew --prefix)
+    PKG_CFLAGS="$BREWDIR/opt/libarchive/include"
+    PKG_LIBS="$BREWDIR/opt/libarchive/lib $PKG_LIBS"
   else
-    curl -sfL "https://jeroen.github.io/autobrew/default" > autobrew
+    curl -sfL "https://autobrew.github.io/scripts/libarchive" > autobrew
     source autobrew
   fi
-  if [ ! $(command -v pkg-config) ]; then
-    # Install pkgconfig and use it to set cflags and libs
-    BREW="$BREWDIR/bin/brew"
-    $BREW install pkgconfig
-    PKG_CONFIG="$BREWDIR/bin/pkg-config"
-  else
-    PKG_CONFIG=$(which pkg-config)
-  fi
-  PKG_CFLAGS=$(PKG_CONFIG_PATH="$BREWDIR/opt/$PKG_BREW_NAME/lib/pkgconfig" $PKG_CONFIG $PKG_BREW_NAME liblzma --cflags)
-  PKG_LIBS=$(PKG_CONFIG_PATH="$BREWDIR/opt/$PKG_BREW_NAME/lib/pkgconfig" $PKG_CONFIG $PKG_BREW_NAME liblzma --libs --static)
 fi
 
 # Find compiler


### PR DESCRIPTION
The autobrew system has changed to support different versions of macos. The [autobrew script](https://autobrew.github.io/scripts/libarchive) will now set `PKG_CFLAGS` and `PKG_LIBS` automatically to the appropriate values.

I also cleaned up some stuff that is now redundant, because we already use pkg-config if available at the beginning of the configure script.

I have tested this to work on several versions of MacOS, with static and dynamic linking.

